### PR TITLE
feat: implement lookup table replace API

### DIFF
--- a/examples/lookupTableReplace.go
+++ b/examples/lookupTableReplace.go
@@ -1,0 +1,38 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mixpanel/mixpanel-go"
+)
+
+func LookupTableReplaceExample() error {
+	ctx := context.Background()
+
+	// fill in your project id and service account user name and secret
+	mp := mixpanel.NewApiClient(
+		"token",
+		// MUST provide service account if you want to use the lookup tables api
+		mixpanel.ServiceAccount(0, "user_name", "secret"),
+	)
+
+	lookupTableID := "some.lookup.table.id"
+	table := [][]string{
+		{
+			"header 1", "header 2",
+		},
+		{
+			"row_1_col_1", "row_1_col2",
+		},
+		{
+			"row_2_col_1", "row_2_col2",
+		},
+	}
+	if err := mp.LookupTableReplace(ctx, lookupTableID, table); err != nil {
+		return err
+	}
+
+	fmt.Println("lookupTableReplace successfully called")
+	return nil
+}

--- a/http.go
+++ b/http.go
@@ -71,6 +71,12 @@ func applicationFormData() httpOptions {
 	}
 }
 
+func textCSVHeader() httpOptions {
+	return func(req *http.Request) {
+		req.Header.Set(contentTypeHeader, contentTypeTextCSV)
+	}
+}
+
 func (m *ApiClient) importAuthOptions() httpOptions {
 	return func(req *http.Request) {
 		if m.serviceAccount != nil {

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -37,6 +37,7 @@ const (
 	contentTypeHeader          = "Content-Type"
 	contentTypeApplicationJson = "application/json"
 	contentTypeApplicationForm = "application/x-www-form-urlencoded"
+	contentTypeTextCSV         = "text/csv"
 )
 
 type Ingestion interface {
@@ -61,6 +62,9 @@ type Ingestion interface {
 	GroupRemoveListProperty(ctx context.Context, groupKey, groupID string, remove map[string]any) error
 	GroupUnionListProperty(ctx context.Context, groupKey, groupID string, union map[string]any) error
 	GroupDelete(ctx context.Context, groupKey, groupID string) error
+
+	// Lookup Tables
+	LookupTableReplace(ctx context.Context, lookupTableID string, table [][]string) error
 }
 
 var _ Ingestion = (*ApiClient)(nil)


### PR DESCRIPTION
Hi! This week, we needed to make use of the [lookup table replace API](https://developer.mixpanel.com/reference/replace-lookup-table) and found out that the SDK here doesn't implement it as of yet.

So here is a quick implementation of the endpoint, incl. tests and and example, which we're already using productively on our end.