### PR TITLE
Allow custom flags exposure trackers and bump to non-prerelease

### DIFF
--- a/examples/localFlags.go
+++ b/examples/localFlags.go
@@ -15,7 +15,7 @@ func InvokeLocalFlagsSample() {
 	config := flags.DefaultLocalFlagsConfig()
 	config.EnablePolling = true
 
-	client := mixpanel.NewApiClient("YOUR_PROJECT_TOKEN", mixpanel.WithLocalFlags(config))
+	client := mixpanel.NewApiClient("YOUR_PROJECT_TOKEN", mixpanel.WithLocalFlags(config, mixpanel.DefaultFlagsExposureTracker))
 
 	if err := client.LocalFlags.StartPollingForDefinitions(ctx); err != nil {
 		log.Fatalf("Failed to start polling: %v", err)

--- a/examples/localFlags.go
+++ b/examples/localFlags.go
@@ -15,7 +15,7 @@ func InvokeLocalFlagsSample() {
 	config := flags.DefaultLocalFlagsConfig()
 	config.EnablePolling = true
 
-	client := mixpanel.NewApiClient("YOUR_PROJECT_TOKEN", mixpanel.WithLocalFlags(config, mixpanel.DefaultFlagsExposureTracker))
+	client := mixpanel.NewApiClient("YOUR_PROJECT_TOKEN", mixpanel.WithLocalFlags(config))
 
 	if err := client.LocalFlags.StartPollingForDefinitions(ctx); err != nil {
 		log.Fatalf("Failed to start polling: %v", err)

--- a/examples/remoteFlags.go
+++ b/examples/remoteFlags.go
@@ -14,7 +14,7 @@ func InvokeRemoteFlagsSample() {
 
 	config := flags.DefaultRemoteFlagsConfig()
 
-	client := mixpanel.NewApiClient("YOUR_PROJECT_TOKEN", mixpanel.WithRemoteFlags(config))
+	client := mixpanel.NewApiClient("YOUR_PROJECT_TOKEN", mixpanel.WithRemoteFlags(config, mixpanel.DefaultFlagsExposureTracker))
 
 	// Define the user context for flag evaluation
 	userContext := flags.FlagContext{

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -188,9 +188,13 @@ func DefaultFlagsExposureTracker(client *ApiClient) flags.Tracker {
 	}
 }
 
-// WithLocalFlags configures a local feature flags provider for the client.
-// If builder is nil, DefaultFlagsExposureTracker is used.
-func WithLocalFlags(config flags.LocalFlagsConfig, builder TrackerBuilder) Options {
+// WithLocalFlags configures a local feature flags provider using the DefaultFlagsExposureTracker.
+func WithLocalFlags(config flags.LocalFlagsConfig) Options {
+	return WithLocalFlagsAndTracker(config, DefaultFlagsExposureTracker)
+}
+
+// WithLocalFlagsAndTracker configures a local feature flags provider with a custom TrackerBuilder.
+func WithLocalFlagsAndTracker(config flags.LocalFlagsConfig, builder TrackerBuilder) Options {
 	return func(mixpanel *ApiClient) {
 		if builder == nil {
 			builder = DefaultFlagsExposureTracker

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -114,7 +114,7 @@ type ApiClient struct {
 
 type Options func(mixpanel *ApiClient)
 
-// TrackerBuilder constructs a delegate that can be used to send exposure events to Mixpanel in a custom manner. 
+// TrackerBuilder constructs a function that can be used to send exposure events to Mixpanel in a custom manner.
 type TrackerBuilder func(client *ApiClient) flags.Tracker
 
 // HttpClient will replace the http.DefaultClient with the provided http.Client
@@ -189,15 +189,23 @@ func DefaultFlagsExposureTracker(client *ApiClient) flags.Tracker {
 }
 
 // WithLocalFlags configures a local feature flags provider for the client.
+// If builder is nil, DefaultFlagsExposureTracker is used.
 func WithLocalFlags(config flags.LocalFlagsConfig, builder TrackerBuilder) Options {
 	return func(mixpanel *ApiClient) {
+		if builder == nil {
+			builder = DefaultFlagsExposureTracker
+		}
 		mixpanel.LocalFlags = flags.NewLocalFeatureFlagsProvider(mixpanel.token, version, config, builder(mixpanel))
 	}
 }
 
 // WithRemoteFlags configures a remote feature flags provider for the client.
+// If builder is nil, DefaultFlagsExposureTracker is used.
 func WithRemoteFlags(config flags.RemoteFlagsConfig, builder TrackerBuilder) Options {
 	return func(mixpanel *ApiClient) {
+		if builder == nil {
+			builder = DefaultFlagsExposureTracker
+		}
 		mixpanel.RemoteFlags = flags.NewRemoteFeatureFlagsProvider(mixpanel.token, version, config, builder(mixpanel))
 	}
 }

--- a/mixpanel.go
+++ b/mixpanel.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version = "v2.0.0-beta.2"
+	version = "v2.0.0"
 
 	usEndpoint     = "https://api.mixpanel.com"
 	usDataEndpoint = "https://data.mixpanel.com"
@@ -114,6 +114,9 @@ type ApiClient struct {
 
 type Options func(mixpanel *ApiClient)
 
+// TrackerBuilder constructs a delegate that can be used to send exposure events to Mixpanel in a custom manner. 
+type TrackerBuilder func(client *ApiClient) flags.Tracker
+
 // HttpClient will replace the http.DefaultClient with the provided http.Client
 func HttpClient(client *http.Client) Options {
 	return func(mixpanel *ApiClient) {
@@ -176,25 +179,26 @@ func DebugHttpCalls(writer io.Writer) Options {
 	}
 }
 
+// DefaultFlagsExposureTracker sends the exposure event synchronously.
+// To send asynchronously, wrap with a goroutine in your own TrackerBuilder.
+func DefaultFlagsExposureTracker(client *ApiClient) flags.Tracker {
+	return func(distinctID string, eventName string, props map[string]any) {
+		event := client.NewEvent(eventName, distinctID, props)
+		_ = client.Track(context.Background(), []*Event{event})
+	}
+}
+
 // WithLocalFlags configures a local feature flags provider for the client.
-func WithLocalFlags(config flags.LocalFlagsConfig) Options {
+func WithLocalFlags(config flags.LocalFlagsConfig, builder TrackerBuilder) Options {
 	return func(mixpanel *ApiClient) {
-		tracker := func(distinctID string, eventName string, props map[string]any) {
-			event := mixpanel.NewEvent(eventName, distinctID, props)
-			_ = mixpanel.Track(context.Background(), []*Event{event})
-		}
-		mixpanel.LocalFlags = flags.NewLocalFeatureFlagsProvider(mixpanel.token, version, config, tracker)
+		mixpanel.LocalFlags = flags.NewLocalFeatureFlagsProvider(mixpanel.token, version, config, builder(mixpanel))
 	}
 }
 
 // WithRemoteFlags configures a remote feature flags provider for the client.
-func WithRemoteFlags(config flags.RemoteFlagsConfig) Options {
+func WithRemoteFlags(config flags.RemoteFlagsConfig, builder TrackerBuilder) Options {
 	return func(mixpanel *ApiClient) {
-		tracker := func(distinctID string, eventName string, props map[string]any) {
-			event := mixpanel.NewEvent(eventName, distinctID, props)
-			_ = mixpanel.Track(context.Background(), []*Event{event})
-		}
-		mixpanel.RemoteFlags = flags.NewRemoteFeatureFlagsProvider(mixpanel.token, version, config, tracker)
+		mixpanel.RemoteFlags = flags.NewRemoteFeatureFlagsProvider(mixpanel.token, version, config, builder(mixpanel))
 	}
 }
 


### PR DESCRIPTION
- Elevating from beta version to v2.0.0
- Adds custom tracker to allow developer to override standard sync tracking with some flavor of async tracking 