### PR TITLE
[DEV-74] chore: add 30-day dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 30
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 30


### PR DESCRIPTION
Adds `cooldown.default-days: 30` to all dependabot ecosystems. This delays PRs until a new dependency version has been stable for 30 days, reducing supply-chain risk from fast-moving malicious releases.

Linear: https://linear.app/mixpanel/issue/DEV-74/ensure-all-repos-have-dependabotyml-with-30-day-cooldown