### PR TITLE
Fix OpenFeature module path to work with Go proxy

### DIFF
--- a/openfeature/README.md
+++ b/openfeature/README.md
@@ -14,7 +14,7 @@ This package provides a bridge between Mixpanel's native feature flags implement
 ## Installation
 
 ```bash
-go get github.com/mixpanel/mixpanel-go/v2/openfeature
+go get github.com/mixpanel/mixpanel-go/openfeature
 ```
 
 You will also need the OpenFeature Go SDK:
@@ -32,7 +32,7 @@ import (
 	"context"
 	"fmt"
 
-	mixpanelopenfeature "github.com/mixpanel/mixpanel-go/v2/openfeature"
+	mixpanelopenfeature "github.com/mixpanel/mixpanel-go/openfeature"
 	"github.com/mixpanel/mixpanel-go/v2/flags"
 	of "github.com/open-feature/go-sdk/openfeature"
 )

--- a/openfeature/RELEASE.md
+++ b/openfeature/RELEASE.md
@@ -1,6 +1,6 @@
 # Releasing the OpenFeature Provider
 
-The OpenFeature provider (`github.com/mixpanel/mixpanel-go/v2/openfeature`) is published as a separate Go module within this repository. It has its own `go.mod` and is versioned independently from the core SDK.
+The OpenFeature provider (`github.com/mixpanel/mixpanel-go/openfeature`) is published as a separate Go module within this repository. It has its own `go.mod` and is versioned independently from the core SDK.
 
 ## Releasing
 
@@ -14,7 +14,7 @@ The OpenFeature provider (`github.com/mixpanel/mixpanel-go/v2/openfeature`) is p
 
 3. The Go module proxy auto-indexes the new version within minutes
 
-4. Verify at https://pkg.go.dev/github.com/mixpanel/mixpanel-go/v2/openfeature
+4. Verify at https://pkg.go.dev/github.com/mixpanel/mixpanel-go/openfeature
 
 No build step, credentials, or upload is needed — the Go proxy pulls directly from the git tag.
 
@@ -25,7 +25,7 @@ The OpenFeature provider is versioned independently from the core SDK. The core 
 ## How users install it
 
 ```bash
-go get github.com/mixpanel/mixpanel-go/v2/openfeature
+go get github.com/mixpanel/mixpanel-go/openfeature
 ```
 
 Because this directory has its own `go.mod`, Go treats it as a separate module. The core SDK is pulled in as a transitive dependency.

--- a/openfeature/go.mod
+++ b/openfeature/go.mod
@@ -1,4 +1,4 @@
-module github.com/mixpanel/mixpanel-go/v2/openfeature
+module github.com/mixpanel/mixpanel-go/openfeature
 
 go 1.22
 


### PR DESCRIPTION
Change module path from github.com/mixpanel/mixpanel-go/v2/openfeature to github.com/mixpanel/mixpanel-go/openfeature. The /v2 major version suffix in the module path caused the Go proxy to look for a v2/openfeature/ directory which doesn't exist. The core SDK dependency is still v2.