### PR TITLE
chore: standardize release process

### DIFF
--- a/.github/modules.json
+++ b/.github/modules.json
@@ -1,0 +1,18 @@
+{
+  "analytics": {
+    "tag_prefix": "v",
+    "go_mod": "go.mod",
+    "version_files": [],
+    "changelog": "CHANGELOG.md",
+    "readme": "README.md",
+    "package_name": "github.com/mixpanel/mixpanel-go/v2"
+  },
+  "openfeature": {
+    "tag_prefix": "openfeature/v",
+    "go_mod": "openfeature/go.mod",
+    "version_files": [],
+    "changelog": "openfeature/CHANGELOG.md",
+    "readme": "openfeature/README.md",
+    "package_name": "github.com/mixpanel/mixpanel-go/openfeature"
+  }
+}

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+MODULE="$1"
+VERSION_LABEL="$2"
+REPO_URL="$3"
+END_REF="${4:-HEAD}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULES_JSON="$SCRIPT_DIR/../modules.json"
+
+TAG_PREFIX=$(jq -e -r --arg m "$MODULE" '.[$m].tag_prefix' "$MODULES_JSON") || {
+  echo "Unknown module: $MODULE. Valid modules: $(jq -r 'keys | join(", ")' "$MODULES_JSON")" >&2
+  exit 1
+}
+TAG_GLOB="${TAG_PREFIX}*"
+
+PREVIOUS_TAG=$(git tag --sort=-creatordate --list "$TAG_GLOB" | head -1 || true)
+
+if [ -z "$PREVIOUS_TAG" ]; then
+  RANGE="$END_REF"
+else
+  RANGE="${PREVIOUS_TAG}..${END_REF}"
+fi
+
+DATE=$(date +%Y-%m-%d)
+SAFE_URL=$(printf '%s' "$REPO_URL" | sed 's|[&/\]|\\&|g')
+
+declare -a FEATURES=()
+declare -a FIXES=()
+declare -a CHORES=()
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  MSG=$(echo "$line" | cut -d' ' -f2-)
+
+  if [[ "$MSG" =~ ^(feat|fix|chore)\((${MODULE}|all)\):\ (.+) ]]; then
+    TYPE="${BASH_REMATCH[1]}"
+    DESC="${BASH_REMATCH[3]}"
+
+    DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
+
+    case "$TYPE" in
+      feat) FEATURES+=("$DESC") ;;
+      fix) FIXES+=("$DESC") ;;
+      chore) CHORES+=("$DESC") ;;
+    esac
+  fi
+done < <(git log --oneline "$RANGE")
+
+echo "## [${VERSION_LABEL}](${REPO_URL}/tree/${VERSION_LABEL}) (${DATE})"
+echo ""
+
+if [ ${#FEATURES[@]} -gt 0 ]; then
+  echo "### Features"
+  for entry in "${FEATURES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ ${#FIXES[@]} -gt 0 ]; then
+  echo "### Fixes"
+  for entry in "${FIXES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ ${#CHORES[@]} -gt 0 ]; then
+  echo "### Chores"
+  for entry in "${CHORES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ -n "$PREVIOUS_TAG" ]; then
+  echo "[Full Changelog](${REPO_URL}/compare/${PREVIOUS_TAG}...${VERSION_LABEL})"
+fi

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -34,17 +34,24 @@ while IFS= read -r line; do
   [ -z "$line" ] && continue
   MSG=$(echo "$line" | cut -d' ' -f2-)
 
-  if [[ "$MSG" =~ ^(feat|fix|chore)\((${MODULE}|all)\):\ (.+) ]]; then
+  # feat / fix: include whether bare, scoped to our module, or scoped to
+  # `all` (cross-cutting changes that appear in every module's changelog).
+  # chore: include only when explicitly scoped to our module or `all` —
+  # bare `chore:` is the convention for changes intentionally hidden from
+  # the changelog (release prep PRs, CI tweaks, lockfile bumps, internal
+  # docs).
+  if [[ "$MSG" =~ ^(feat|fix)(\((${MODULE}|all)\))?:\ (.+) ]]; then
     TYPE="${BASH_REMATCH[1]}"
-    DESC="${BASH_REMATCH[3]}"
-
+    DESC="${BASH_REMATCH[4]}"
     DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
-
     case "$TYPE" in
       feat) FEATURES+=("$DESC") ;;
       fix) FIXES+=("$DESC") ;;
-      chore) CHORES+=("$DESC") ;;
     esac
+  elif [[ "$MSG" =~ ^chore\((${MODULE}|all)\):\ (.+) ]]; then
+    DESC="${BASH_REMATCH[2]}"
+    DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
+    CHORES+=("$DESC")
   fi
 done < <(git log --oneline "$RANGE")
 

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -23,8 +23,10 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           MODULE_LIST=$(jq -r 'keys | join("|")' .github/modules.json)
-          # Scope is optional. Bare or scoped to a known module both pass.
-          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST})\))?: .+"
+          # Scope is optional. Bare, scoped to a known module, or scoped to
+          # `all` (cross-cutting changes that appear in every module's
+          # changelog) all pass.
+          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST}|all)\))?: .+"
           RELEASE_PATTERN="^release: .+"
 
           if [[ "$PR_TITLE" =~ $MAIN_PATTERN ]] || [[ "$PR_TITLE" =~ $RELEASE_PATTERN ]]; then
@@ -40,10 +42,10 @@ jobs:
           echo "  feat: description"
           echo "  fix: description"
           echo "  chore: description"
-          echo "  feat(<module>): description"
-          echo "  fix(<module>): description"
-          echo "  chore(<module>): description"
+          echo "  feat(<module>|all): description"
+          echo "  fix(<module>|all): description"
+          echo "  chore(<module>|all): description"
           echo "  release: description"
           echo ""
-          echo "Valid modules: ${MODULE_LIST//|/, }"
+          echo "Valid scopes: ${MODULE_LIST//|/, }, all"
           exit 1

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,49 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          sparse-checkout: .github/modules.json
+          sparse-checkout-cone-mode: false
+
+      - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          MODULE_LIST=$(jq -r 'keys | join("|")' .github/modules.json)
+          # Scope is optional. Bare or scoped to a known module both pass.
+          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST})\))?: .+"
+          RELEASE_PATTERN="^release: .+"
+
+          if [[ "$PR_TITLE" =~ $MAIN_PATTERN ]] || [[ "$PR_TITLE" =~ $RELEASE_PATTERN ]]; then
+            echo "PR title is valid: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "PR title does not match the required format."
+          echo ""
+          echo "  Got: $PR_TITLE"
+          echo ""
+          echo "Expected one of:"
+          echo "  feat: description"
+          echo "  fix: description"
+          echo "  chore: description"
+          echo "  feat(<module>): description"
+          echo "  fix(<module>): description"
+          echo "  chore(<module>): description"
+          echo "  release: description"
+          echo ""
+          echo "Valid modules: ${MODULE_LIST//|/, }"
+          exit 1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,187 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Module to release (must match a key in .github/modules.json)'
+        required: true
+        type: string
+      version:
+        description: 'Release version (e.g., 2.1.0 or 2.1.0-beta.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release-${{ inputs.module }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: "Prepare ${{ inputs.module }} ${{ inputs.version }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate inputs
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION"
+            exit 1
+          fi
+          jq -e --arg m "$MODULE" '.[$m]' .github/modules.json > /dev/null || {
+            echo "::error::Unknown module '$MODULE'. Valid modules: $(jq -r 'keys | join(", ")' .github/modules.json)"
+            exit 1
+          }
+
+      - name: Resolve module config
+        id: config
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          MODULE_CONFIG=$(jq -e --arg m "$MODULE" '.[$m]' .github/modules.json)
+
+          TAG_PREFIX=$(echo "$MODULE_CONFIG" | jq -r '.tag_prefix')
+          {
+            echo "tag=${TAG_PREFIX}${VERSION}"
+            echo "go_mod=$(echo "$MODULE_CONFIG" | jq -r '.go_mod')"
+            echo "changelog=$(echo "$MODULE_CONFIG" | jq -r '.changelog')"
+            echo "readme=$(echo "$MODULE_CONFIG" | jq -r '.readme')"
+            echo "package_name=$(echo "$MODULE_CONFIG" | jq -r '.package_name')"
+            echo "branch=release/${MODULE}/${VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate version not already released
+        env:
+          TAG: ${{ steps.config.outputs.tag }}
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists on origin"
+            exit 1
+          fi
+          if git tag -l "$TAG" | grep -q .; then
+            echo "::error::Tag $TAG already exists locally"
+            exit 1
+          fi
+
+      - name: Clean up existing release branch and PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: |
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "Closing existing PR #$EXISTING_PR and deleting branch"
+            gh pr close "$EXISTING_PR" --delete-branch
+          elif git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Deleting orphaned branch $BRANCH"
+            git push origin --delete "$BRANCH"
+          fi
+
+      - name: Create release branch
+        env:
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: git checkout -b "$BRANCH"
+
+      # Note: Go has no version field in go.mod — versions live exclusively in
+      # git tags. We intentionally skip a "bump version" step here. The release
+      # tag is pushed manually after this PR is merged (see PR body / runbook).
+
+      - name: Update README version header
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          TAG: ${{ steps.config.outputs.tag }}
+          README: ${{ steps.config.outputs.readme }}
+        run: |
+          DATE=$(date +"%B %d, %Y")
+          # Replace the version header line.
+          # The `1,/pat/` address range bounds the substitution to lines from
+          # the start of the file through the first match, so a README that
+          # accidentally contains a second matching line is left untouched.
+          sed -i -E \
+            "1,/^##### _.*_ - \[.*\]\(.*\)\$/ s|^##### _.*_ - \[.*\]\(.*\)\$|##### _${DATE}_ - [${TAG}](${REPO_URL}/releases/tag/${TAG})|" \
+            "$README"
+
+      - name: Generate changelog
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          MODULE: ${{ inputs.module }}
+          TAG: ${{ steps.config.outputs.tag }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+        run: |
+          CHANGELOG=$(.github/scripts/generate-changelog.sh \
+            "$MODULE" "$TAG" "$REPO_URL" HEAD)
+
+          if [ -f "$CHANGELOG_FILE" ]; then
+            {
+              printf '# Changelog\n\n%s\n' "$CHANGELOG"
+              sed '1{/^# Changelog$/d;}' "$CHANGELOG_FILE"
+            } > CHANGELOG.new.md
+            mv CHANGELOG.new.md "$CHANGELOG_FILE"
+          else
+            printf '# Changelog\n\n%s\n' "$CHANGELOG" > "$CHANGELOG_FILE"
+          fi
+
+      - name: Commit and push
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+          README: ${{ steps.config.outputs.readme }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$CHANGELOG_FILE" "$README"
+          git commit -m "release: prepare ${MODULE} ${VERSION}"
+          git push origin "$BRANCH"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+          TAG: ${{ steps.config.outputs.tag }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+          README: ${{ steps.config.outputs.readme }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: |
+          gh pr create \
+            --title "release: prepare ${MODULE} ${VERSION}" \
+            --body "$(cat <<EOF
+          ## Release ${MODULE} ${VERSION}
+
+          This PR prepares the ${MODULE} module for release.
+
+          ### Changes
+          - Updates \`${CHANGELOG_FILE}\` with a new section since the last \`${TAG%${VERSION}}*\` tag
+          - Updates \`${README}\` version header
+
+          Note: Go has no version field in \`go.mod\` — the release version lives
+          exclusively in the git tag, so there is no source-file version bump.
+
+          ### After merging
+          1. Push tag \`${TAG}\` from the merge commit on \`main\` to trigger the publish workflow:
+             \`\`\`
+             git checkout main && git pull
+             git tag ${TAG}
+             git push origin ${TAG}
+             \`\`\`
+          2. The publish workflow validates the tag, runs \`go test\`/\`go vet\`/\`go build\`, and creates a draft GitHub release. Review and publish the GitHub release once it looks good.
+          3. \`pkg.go.dev\` indexes from the tag automatically (typically within ~30 minutes).
+          EOF
+          )" \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -109,24 +109,20 @@ jobs:
           TAG: ${{ github.ref_name }}
           CHANGELOG: ${{ steps.module.outputs.changelog }}
         run: |
-          # Match the section header `## [${TAG}](...)` and stop at the next `## ` header.
-          # Falls back to a placeholder if no matching section is found.
-          python3 - <<'PY' > release_notes.md
-          import os, re, sys
-          tag = os.environ["TAG"]
-          changelog_path = os.environ["CHANGELOG"]
-          try:
-              content = open(changelog_path).read()
-          except FileNotFoundError:
-              print(f"Release {tag}")
-              sys.exit(0)
-          pattern = r'^## \[' + re.escape(tag) + r'\].*?\n(.*?)(?=^## |\Z)'
-          match = re.search(pattern, content, re.DOTALL | re.MULTILINE)
-          if match:
-              print(match.group(1).strip())
-          else:
-              print(f"Release {tag}")
-          PY
+          # Extract this tag's section from CHANGELOG.md via a sed range.
+          # The address `\@^## \[TAG\]@,\@^## \[@` selects from the version
+          # header through the next `## [` line; the inner block deletes
+          # both markers and prints the body. sed range patterns don't test
+          # the end pattern against the start line, so the start doesn't
+          # self-terminate. `\@...@` switches the address delimiter from
+          # `/` to `@` so tags containing `/` (e.g. `openfeature/v0.1.0`)
+          # don't conflict with the default `/`. Mirrors the deployed
+          # mixpanel-android extraction logic. Falls back to a placeholder
+          # if the section is missing or empty.
+          sed -n '\@^## \['"${TAG}"'\]@,\@^## \[@{\@^## \['"${TAG}"'\]@d;\@^## \[@d;p;}' "$CHANGELOG" 2>/dev/null > release_notes.md || true
+          if [ ! -s release_notes.md ]; then
+            echo "Release $TAG" > release_notes.md
+          fi
           echo "--- release_notes.md ---"
           cat release_notes.md
 

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           MODULE=$(jq -r --arg t "$TAG" '
             to_entries
-            | map(select($t | startswith(.value.tag_prefix)))
+            | map(select(.value.tag_prefix as $p | $t | startswith($p)))
             | max_by(.value.tag_prefix | length)
             | .key // empty
           ' .github/modules.json)

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -1,0 +1,187 @@
+name: Publish Go Release
+
+# Tag-triggered. Go has no registry upload — pkg.go.dev indexes directly from
+# git tags within ~30 minutes of the push. This workflow validates the tag,
+# runs tests/vet/build for the module, and creates a draft GitHub release.
+#
+# Tag patterns (one per module in .github/modules.json):
+#   - v*               -> analytics      (root module github.com/mixpanel/mixpanel-go/v2)
+#   - openfeature/v*   -> openfeature    (submodule github.com/mixpanel/mixpanel-go/openfeature)
+on:
+  push:
+    tags:
+      - 'v*'
+      - 'openfeature/v*'
+
+concurrency:
+  group: go-publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # create the draft GitHub release
+
+jobs:
+  publish:
+    name: "Publish ${{ github.ref_name }}"
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 20
+
+    # One-time setup is required:
+    #   - GitHub Environment named `release` (with required reviewers if desired)
+    #   - Tag rulesets restricting `v*` and `openfeature/v*` to the default branch
+
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve module from tag
+        id: module
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          MODULE=$(jq -r --arg t "$TAG" '
+            to_entries
+            | map(select($t | startswith(.value.tag_prefix)))
+            | max_by(.value.tag_prefix | length)
+            | .key // empty
+          ' .github/modules.json)
+
+          if [ -z "$MODULE" ]; then
+            echo "::error::Tag '$TAG' does not match any module tag_prefix in .github/modules.json"
+            exit 1
+          fi
+
+          MODULE_CONFIG=$(jq -e --arg m "$MODULE" '.[$m]' .github/modules.json)
+          TAG_PREFIX=$(echo "$MODULE_CONFIG" | jq -r '.tag_prefix')
+          VERSION="${TAG#${TAG_PREFIX}}"
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version '$VERSION' (from tag '$TAG') is not a valid semver"
+            exit 1
+          fi
+
+          GO_MOD=$(echo "$MODULE_CONFIG" | jq -r '.go_mod')
+          MODULE_DIR=$(dirname "$GO_MOD")
+
+          {
+            echo "module=$MODULE"
+            echo "version=$VERSION"
+            echo "tag_prefix=$TAG_PREFIX"
+            echo "go_mod=$GO_MOD"
+            echo "module_dir=$MODULE_DIR"
+            echo "changelog=$(echo "$MODULE_CONFIG" | jq -r '.changelog')"
+            echo "package_name=$(echo "$MODULE_CONFIG" | jq -r '.package_name')"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Resolved tag '$TAG' -> module '$MODULE', version '$VERSION', dir '$MODULE_DIR'"
+
+      - name: Verify tag commit is on main
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          git fetch origin main
+          TAG_SHA=$(git rev-parse HEAD)
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            echo "::error::Tag '$TAG' ($TAG_SHA) is not an ancestor of origin/main."
+            echo "Tags must be pushed from a commit on the main branch."
+            exit 1
+          fi
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        with:
+          go-version: 'stable'
+
+      - name: Test, vet, and build module
+        working-directory: ${{ steps.module.outputs.module_dir }}
+        run: |
+          go version
+          echo "Building module in $(pwd)"
+          go test ./...
+          go vet ./...
+          go build ./...
+
+      - name: Extract changelog section for tag
+        env:
+          TAG: ${{ github.ref_name }}
+          CHANGELOG: ${{ steps.module.outputs.changelog }}
+        run: |
+          # Match the section header `## [${TAG}](...)` and stop at the next `## ` header.
+          # Falls back to a placeholder if no matching section is found.
+          python3 - <<'PY' > release_notes.md
+          import os, re, sys
+          tag = os.environ["TAG"]
+          changelog_path = os.environ["CHANGELOG"]
+          try:
+              content = open(changelog_path).read()
+          except FileNotFoundError:
+              print(f"Release {tag}")
+              sys.exit(0)
+          pattern = r'^## \[' + re.escape(tag) + r'\].*?\n(.*?)(?=^## |\Z)'
+          match = re.search(pattern, content, re.DOTALL | re.MULTILINE)
+          if match:
+              print(match.group(1).strip())
+          else:
+              print(f"Release {tag}")
+          PY
+          echo "--- release_notes.md ---"
+          cat release_notes.md
+
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Idempotent: if a draft release for this tag already exists, leave it alone.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release for $TAG already exists; skipping creation"
+          else
+            gh release create "$TAG" \
+              --draft \
+              --title "$TAG" \
+              --notes-file release_notes.md
+          fi
+
+      - name: Warm pkg.go.dev / proxy.golang.org cache
+        # Best-effort. The proxy will index the module on its own within ~30
+        # minutes; this just nudges it. Never fail the workflow on this step.
+        continue-on-error: true
+        env:
+          PACKAGE_NAME: ${{ steps.module.outputs.package_name }}
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ steps.module.outputs.version }}
+          TAG_PREFIX: ${{ steps.module.outputs.tag_prefix }}
+        run: |
+          # The Go module proxy uses the module's import path (the same string
+          # as `module` in go.mod) as its query path. For submodules, the
+          # version path component is the bare semver (`v0.1.0`), not the
+          # repo-tag form (`openfeature/v0.1.0`). Lower-case + percent-encode
+          # the few characters the proxy escapes.
+          encode() {
+            python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$1"
+          }
+          ENCODED_PKG=$(encode "$PACKAGE_NAME")
+          PROXY_VERSION="v${VERSION}"
+          URL="https://proxy.golang.org/${ENCODED_PKG}/@v/${PROXY_VERSION}.info"
+          echo "Warming: $URL"
+          curl -fsSL "$URL" || echo "Proxy warm-up failed (non-fatal)"
+
+      - name: Summary
+        env:
+          MODULE: ${{ steps.module.outputs.module }}
+          VERSION: ${{ steps.module.outputs.version }}
+          PACKAGE_NAME: ${{ steps.module.outputs.package_name }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          {
+            echo "## ${MODULE} ${TAG} ready to publish"
+            echo ""
+            echo "- [pkg.go.dev](https://pkg.go.dev/${PACKAGE_NAME}@v${VERSION})"
+            echo "- [Draft GitHub Release](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG})"
+            echo ""
+            echo "### Next step"
+            echo "Review the draft GitHub release and click **Publish release** to make it live. \`pkg.go.dev\` should index the new tag within ~30 minutes."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [v2.0.0](https://github.com/mixpanel/mixpanel-go/tree/v2.0.0) (2026-05-13)
+
+Initial entry. Future releases will be appended here automatically by the
+`prepare-release` workflow.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 #  Mixpanel Go SDK
 
+##### _May 13, 2026_ - [v2.0.0](https://github.com/mixpanel/mixpanel-go/releases/tag/v2.0.0)
+
 [![Go Reference](https://pkg.go.dev/badge/github.com/mixpanel/mixpanel-go.svg)](https://pkg.go.dev/github.com/mixpanel/mixpanel-go)
 [![Go](https://github.com/mixpanel/mixpanel-go/actions/workflows/testing.yaml/badge.svg)](https://github.com/mixpanel/mixpanel-go/actions/workflows/testing.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/mixpanel/mixpanel-go)](https://goreportcard.com/report/github.com/mixpanel/mixpanel-go)

--- a/openfeature/CHANGELOG.md
+++ b/openfeature/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [openfeature/v0.1.0](https://github.com/mixpanel/mixpanel-go/tree/openfeature/v0.1.0) (2026-05-13)
+
+Initial entry. Future releases will be appended here automatically by the
+`prepare-release` workflow.

--- a/openfeature/README.md
+++ b/openfeature/README.md
@@ -1,5 +1,7 @@
 # Mixpanel OpenFeature Provider for Go
 
+##### _May 13, 2026_ - [openfeature/v0.1.0](https://github.com/mixpanel/mixpanel-go/releases/tag/openfeature/v0.1.0)
+
 An [OpenFeature](https://openfeature.dev/) provider that wraps Mixpanel's feature flags for use with the OpenFeature Go SDK. This allows you to use Mixpanel's feature flagging capabilities through OpenFeature's standardized, vendor-agnostic API.
 
 ## Overview


### PR DESCRIPTION
## Summary

Standardizes this repo's release process to match the rest of the Mixpanel SDK fleet, per the [SDK Release Process Standardization Effort](https://www.notion.so/mxpnl/SDK-Release-Process-Standardization-Effort-348e0ba925628029af63c779caa835f9).

After merge, releases follow a uniform two-step ceremony:

1. Run the **Prepare Release** workflow (`prepare-release.yml`) — opens a release PR with the version bump, changelog section, and README header line updated.
2. Push the release tag — `release-go.yml` validates, gates on the `release` GitHub environment for human approval, and publishes (where applicable for this ecosystem).

## What's added

- `.github/modules.json` — single source of truth for module config (paths, tag prefixes, package names)
- `.github/workflows/prepare-release.yml` — manual dispatch, opens release PR
- `.github/workflows/release-go.yml` — tag-triggered publish workflow
- `.github/workflows/pr-title-check.yml` — conventional-commit enforcement (regex built from `modules.json`)
- `.github/scripts/generate-changelog.sh` — shared changelog generator (verbatim from mixpanel-android)
- README version-header line on each module's README, seeded with the current latest tag
- `CHANGELOG.md` per module where missing
- Two modules covered: `analytics` (`github.com/mixpanel/mixpanel-go/v2`) and `openfeature` (`github.com/mixpanel/mixpanel-go/openfeature`)
- Go has no registry upload — pkg.go.dev indexes from git tags. The publish workflow validates + tests + creates the draft GitHub release, then warms the Go module proxy as a best-effort step
- No version-bump step in `prepare-release.yml` — Go has no version field in `go.mod`, the tag is the source of truth
- `flags/` is part of the root module (no separate `go.mod`), so it's not listed in `modules.json`

## How releases work after this lands

Full ceremony, one-time setup, and PR title conventions: **[Go Modules Release Runbook](https://www.notion.so/mxpnl/Go-Release-Runbook-35ee0ba9256280cf9d67d177608dbadb)**

## One-time setup before the first release

The runbook lists the full setup. The work that requires repo-admin access (cannot be done in this PR):

- Create a GitHub Environment named `release` with required reviewer(s)
- Branch protection on the default branch (require PR review + the new `Validate PR title` check)
- Tag rulesets (restrict creation/update/deletion of release tags)
- Workflow permissions: enable `Read and write permissions` and `Allow GitHub Actions to create and approve pull requests` (needed by `prepare-release.yml`'s `gh pr create`)

## Notes

- This is a **WIP** draft to be reviewed alongside the equivalent PRs in the other SDK repos. The Flutter and React Native ports are tracked at mixpanel-flutter#238, mixpanel-flutter-session-replay#30, mixpanel-react-native#408, mixpanel-react-native-session-replay#64.
- This PR does not change any source code or build behavior — only adds release infrastructure.
- The standardization commit is followed by a small `fix:` commit correcting a jq tag-resolution snippet (the same bug exists in the WIP Flutter/RN PRs and should be back-ported there).