### PR TITLE
feat(analytics): add VariantSource + FallbackReason fields (SDK-79)

### DIFF
--- a/flags/localFlags.go
+++ b/flags/localFlags.go
@@ -136,12 +136,12 @@ func (p *LocalFeatureFlagsProvider) GetVariant(ctx context.Context, flagKey stri
 	flag, exists := (*flags)[flagKey]
 
 	if !exists {
-		return fallbackVariant, nil
+		return fallbackVariant.AsFallback(FallbackReasonFlagNotFound), nil
 	}
 
 	contextValue, ok := flagContext[flag.Context]
 	if !ok {
-		return fallbackVariant, nil
+		return fallbackVariant.AsFallback(FallbackReasonMissingContextKey), nil
 	}
 
 	var selectedVariant *SelectedVariant
@@ -151,7 +151,7 @@ func (p *LocalFeatureFlagsProvider) GetVariant(ctx context.Context, flagKey stri
 	} else {
 		rollout, err := p.getAssignedRollout(flag, contextValue, flagContext)
 		if err != nil {
-			return fallbackVariant, err
+			return fallbackVariant.AsFallback(FallbackReasonBackendError), err
 		}
 		if rollout != nil {
 			selectedVariant = p.getAssignedVariant(flag, contextValue, flagKey, rollout)
@@ -163,10 +163,10 @@ func (p *LocalFeatureFlagsProvider) GetVariant(ctx context.Context, flagKey stri
 			latency := time.Since(startTime)
 			p.trackExposure(flagKey, *selectedVariant, flagContext, &latency)
 		}
-		return *selectedVariant, nil
+		return selectedVariant.WithSource(VariantSourceLocal), nil
 	}
 
-	return fallbackVariant, nil
+	return fallbackVariant.AsFallback(FallbackReasonNoRolloutMatch), nil
 }
 
 // GetAllVariants returns all flag variants for the context (no exposure tracking)

--- a/flags/localFlags_test.go
+++ b/flags/localFlags_test.go
@@ -515,6 +515,77 @@ func TestLocalFeatureFlagsProvider_VariantSplits(t *testing.T) {
 	})
 }
 
+// SDK-79: every fallback path on get_variant must be tagged distinctly via
+// VariantSource so the OpenFeature wrapper can map it correctly.
+func TestLocalFeatureFlagsProvider_GetVariant_VariantSourceTagging(t *testing.T) {
+	makeFlag := func(rolloutPct float64, ctxKey string) ExperimentationFlag {
+		return ExperimentationFlag{
+			Key:     "test-flag",
+			Context: ctxKey,
+			Ruleset: RuleSet{
+				Variants: []Variant{
+					{Key: "control", Value: "control", IsControl: true, Split: 100.0},
+				},
+				Rollout: []Rollout{{RolloutPercentage: rolloutPct}},
+			},
+		}
+	}
+
+	setup := func(t *testing.T, defs []ExperimentationFlag) *LocalFeatureFlagsProvider {
+		t.Helper()
+		httpmock.Activate()
+		t.Cleanup(httpmock.DeactivateAndReset)
+
+		config := DefaultLocalFlagsConfig()
+		config.EnablePolling = false
+		provider := NewLocalFeatureFlagsProvider("test-token", "test", config, nil)
+
+		httpmock.RegisterResponder(http.MethodGet, "https://api.mixpanel.com/flags/definitions",
+			httpmock.NewJsonResponderOrPanic(200, experimentationFlagsResponse{Flags: defs}))
+		require.NoError(t, provider.StartPollingForDefinitions(context.Background())) //nolint:contextcheck
+
+		return provider
+	}
+
+	t.Run("tags matched variants as local with no fallback_reason", func(t *testing.T) {
+		provider := setup(t, []ExperimentationFlag{makeFlag(100.0, "distinct_id")})
+		result, err := provider.GetVariant(context.Background(), "test-flag",
+			SelectedVariant{VariantValue: "fb"}, FlagContext{"distinct_id": "u1"}, false)
+		require.NoError(t, err)
+		require.Equal(t, VariantSourceLocal, result.VariantSource)
+		require.Empty(t, result.FallbackReason)
+		require.NotNil(t, result.VariantKey)
+	})
+
+	t.Run("tags missing flag as fallback / FLAG_NOT_FOUND", func(t *testing.T) {
+		provider := setup(t, nil)
+		result, err := provider.GetVariant(context.Background(), "missing",
+			SelectedVariant{VariantValue: "fb"}, FlagContext{"distinct_id": "u1"}, false)
+		require.NoError(t, err)
+		require.Equal(t, VariantSourceFallback, result.VariantSource)
+		require.Equal(t, FallbackReasonFlagNotFound, result.FallbackReason)
+		require.Equal(t, "fb", result.VariantValue)
+	})
+
+	t.Run("tags missing context as fallback / MISSING_CONTEXT_KEY", func(t *testing.T) {
+		provider := setup(t, []ExperimentationFlag{makeFlag(100.0, "distinct_id")})
+		result, err := provider.GetVariant(context.Background(), "test-flag",
+			SelectedVariant{VariantValue: "fb"}, FlagContext{}, false)
+		require.NoError(t, err)
+		require.Equal(t, VariantSourceFallback, result.VariantSource)
+		require.Equal(t, FallbackReasonMissingContextKey, result.FallbackReason)
+	})
+
+	t.Run("tags no-rollout-match as fallback / NO_ROLLOUT_MATCH", func(t *testing.T) {
+		provider := setup(t, []ExperimentationFlag{makeFlag(0.0, "distinct_id")})
+		result, err := provider.GetVariant(context.Background(), "test-flag",
+			SelectedVariant{VariantValue: "fb"}, FlagContext{"distinct_id": "u1"}, false)
+		require.NoError(t, err)
+		require.Equal(t, VariantSourceFallback, result.VariantSource)
+		require.Equal(t, FallbackReasonNoRolloutMatch, result.FallbackReason)
+	})
+}
+
 func TestLowercaseKeysAndValues(t *testing.T) {
 	t.Run("lowercases string keys and values", func(t *testing.T) {
 		input := map[string]any{

--- a/flags/localFlags_test.go
+++ b/flags/localFlags_test.go
@@ -584,6 +584,36 @@ func TestLocalFeatureFlagsProvider_GetVariant_VariantSourceTagging(t *testing.T)
 		require.Equal(t, VariantSourceFallback, result.VariantSource)
 		require.Equal(t, FallbackReasonNoRolloutMatch, result.FallbackReason)
 	})
+
+	t.Run("tags rollout-evaluation failure as fallback / BACKEND_ERROR", func(t *testing.T) {
+		// An unknown jsonlogic operator makes the rule evaluation return
+		// an error, which the provider surfaces as FallbackReasonBackendError.
+		flagWithBadRule := ExperimentationFlag{
+			ID:      "flag-1",
+			Key:     "test-flag",
+			Context: "distinct_id",
+			Ruleset: RuleSet{
+				Variants: []Variant{{Key: "v", Value: "x", Split: 1.0}},
+				Rollout: []Rollout{
+					{
+						RolloutPercentage: 1.0,
+						RuntimeEvaluationRule: map[string]any{
+							"this-is-not-a-real-operator": []any{1, 2},
+						},
+					},
+				},
+			},
+		}
+		provider := setup(t, []ExperimentationFlag{flagWithBadRule})
+		result, err := provider.GetVariant(context.Background(), "test-flag",
+			SelectedVariant{VariantValue: "fb"},
+			FlagContext{"distinct_id": "u1", "custom_properties": map[string]any{"k": "v"}},
+			false)
+		require.Error(t, err)
+		require.Equal(t, VariantSourceFallback, result.VariantSource)
+		require.Equal(t, FallbackReasonBackendError, result.FallbackReason)
+		require.Equal(t, "fb", result.VariantValue)
+	})
 }
 
 func TestLowercaseKeysAndValues(t *testing.T) {

--- a/flags/remoteFlags.go
+++ b/flags/remoteFlags.go
@@ -69,21 +69,25 @@ func (p *RemoteFeatureFlagsProvider) GetVariant(ctx context.Context, flagKey str
 
 	response, err := p.fetchFlags(ctx, flagContext, &flagKey)
 	if err != nil {
-		return fallbackVariant, fmt.Errorf("failed to fetch flags: %w", err)
+		return fallbackVariant.AsFallback(FallbackReasonBackendError), fmt.Errorf("failed to fetch flags: %w", err)
 	}
 
 	latency := time.Since(startTime)
 
 	selectedVariant, ok := response.Flags[flagKey]
 	if !ok || selectedVariant == nil {
-		return fallbackVariant, nil
+		// The /flags endpoint only returns variants the user is enrolled in,
+		// so a missing key could mean the flag doesn't exist OR the user
+		// isn't in any rollout. The remote SDK can't tell them apart without
+		// server-side help — surface as FLAG_NOT_FOUND for now.
+		return fallbackVariant.AsFallback(FallbackReasonFlagNotFound), nil
 	}
 
 	if reportExposure {
 		p.trackExposure(flagKey, *selectedVariant, flagContext, &latency)
 	}
 
-	return *selectedVariant, nil
+	return selectedVariant.WithSource(VariantSourceRemote), nil
 }
 
 // GetAllVariants returns all flag variants for the context from the remote server
@@ -96,7 +100,7 @@ func (p *RemoteFeatureFlagsProvider) GetAllVariants(ctx context.Context, flagCon
 	result := make(map[string]SelectedVariant)
 	for key, variant := range response.Flags {
 		if variant != nil {
-			result[key] = *variant
+			result[key] = variant.WithSource(VariantSourceRemote)
 		}
 	}
 

--- a/flags/remoteFlags_test.go
+++ b/flags/remoteFlags_test.go
@@ -178,6 +178,61 @@ func TestRemoteFeatureFlagsProvider_GetAllVariants(t *testing.T) {
 	})
 }
 
+func TestRemoteFeatureFlagsProvider_VariantSourceTagging(t *testing.T) {
+	t.Run("successful variant is tagged as remote with no fallback reason", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		variantKey := "treatment"
+		response := remoteFlagsResponse{
+			Code: 200,
+			Flags: map[string]*SelectedVariant{
+				"test-flag": {VariantKey: &variantKey, VariantValue: true},
+			},
+		}
+		httpmock.RegisterResponder(http.MethodGet, "https://api.mixpanel.com/flags",
+			httpmock.NewJsonResponderOrPanic(200, response))
+
+		provider := NewRemoteFeatureFlagsProvider("test-token", "test", DefaultRemoteFlagsConfig(), nil)
+		result, err := provider.GetVariant(context.Background(), "test-flag",
+			SelectedVariant{VariantValue: "fb"}, FlagContext{"distinct_id": "u1"}, false)
+		require.NoError(t, err)
+		require.Equal(t, VariantSourceRemote, result.VariantSource)
+		require.Empty(t, result.FallbackReason)
+	})
+
+	t.Run("missing flag is tagged as fallback / FLAG_NOT_FOUND", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder(http.MethodGet, "https://api.mixpanel.com/flags",
+			httpmock.NewJsonResponderOrPanic(200, remoteFlagsResponse{Code: 200, Flags: map[string]*SelectedVariant{}}))
+
+		provider := NewRemoteFeatureFlagsProvider("test-token", "test", DefaultRemoteFlagsConfig(), nil)
+		result, err := provider.GetVariant(context.Background(), "missing-flag",
+			SelectedVariant{VariantValue: "fb"}, FlagContext{"distinct_id": "u1"}, false)
+		require.NoError(t, err)
+		require.Equal(t, VariantSourceFallback, result.VariantSource)
+		require.Equal(t, FallbackReasonFlagNotFound, result.FallbackReason)
+	})
+
+	t.Run("network failure is tagged as fallback / BACKEND_ERROR", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder(http.MethodGet, "https://api.mixpanel.com/flags",
+			httpmock.NewStringResponder(500, "boom"))
+
+		provider := NewRemoteFeatureFlagsProvider("test-token", "test", DefaultRemoteFlagsConfig(), nil)
+		result, err := provider.GetVariant(context.Background(), "any-flag",
+			SelectedVariant{VariantValue: "fb"}, FlagContext{"distinct_id": "u1"}, false)
+		require.Error(t, err)
+		require.Equal(t, VariantSourceFallback, result.VariantSource)
+		require.Equal(t, FallbackReasonBackendError, result.FallbackReason)
+		require.Equal(t, "fb", result.VariantValue)
+	})
+}
+
 func TestRemoteFeatureFlagsProvider_ExposureTracking(t *testing.T) {
 	t.Run("tracks exposure event with correct properties", func(t *testing.T) {
 		httpmock.Activate()

--- a/flags/types.go
+++ b/flags/types.go
@@ -69,10 +69,6 @@ const (
 // when VariantSource == VariantSourceFallback. Matches the constant set used by
 // mixpanel-php so the OpenFeature wrapper can map each reason to the
 // spec-correct error code instead of collapsing every fallback to FLAG_NOT_FOUND.
-//
-// Note: the wrapper handles PROVIDER_NOT_READY by short-circuiting before
-// invoking the provider, so there is no FallbackReasonNotReady here — no
-// producer would ever construct it.
 const (
 	FallbackReasonFlagNotFound      = "FLAG_NOT_FOUND"
 	FallbackReasonMissingContextKey = "MISSING_CONTEXT_KEY"

--- a/flags/types.go
+++ b/flags/types.go
@@ -69,12 +69,15 @@ const (
 // when VariantSource == VariantSourceFallback. Matches the constant set used by
 // mixpanel-php so the OpenFeature wrapper can map each reason to the
 // spec-correct error code instead of collapsing every fallback to FLAG_NOT_FOUND.
+//
+// Note: the wrapper handles PROVIDER_NOT_READY by short-circuiting before
+// invoking the provider, so there is no FallbackReasonNotReady here — no
+// producer would ever construct it.
 const (
 	FallbackReasonFlagNotFound      = "FLAG_NOT_FOUND"
 	FallbackReasonMissingContextKey = "MISSING_CONTEXT_KEY"
 	FallbackReasonNoRolloutMatch    = "NO_ROLLOUT_MATCH"
 	FallbackReasonBackendError      = "BACKEND_ERROR"
-	FallbackReasonNotReady          = "NOT_READY"
 )
 
 type SelectedVariant struct {

--- a/flags/types.go
+++ b/flags/types.go
@@ -56,12 +56,52 @@ func DefaultRemoteFlagsConfig() RemoteFlagsConfig {
 	}
 }
 
+// VariantSource — where a SelectedVariant came from. Set by the providers on
+// every returned variant. Coarse-grained (local / remote / fallback); see
+// FallbackReason for the specific reason behind a fallback.
+const (
+	VariantSourceLocal    = "local"
+	VariantSourceRemote   = "remote"
+	VariantSourceFallback = "fallback"
+)
+
+// FallbackReason — why the SDK returned the developer fallback. Only meaningful
+// when VariantSource == VariantSourceFallback. Matches the constant set used by
+// mixpanel-php so the OpenFeature wrapper can map each reason to the
+// spec-correct error code instead of collapsing every fallback to FLAG_NOT_FOUND.
+const (
+	FallbackReasonFlagNotFound      = "FLAG_NOT_FOUND"
+	FallbackReasonMissingContextKey = "MISSING_CONTEXT_KEY"
+	FallbackReasonNoRolloutMatch    = "NO_ROLLOUT_MATCH"
+	FallbackReasonBackendError      = "BACKEND_ERROR"
+	FallbackReasonNotReady          = "NOT_READY"
+)
+
 type SelectedVariant struct {
 	VariantKey         *string `json:"variant_key"`
 	VariantValue       any     `json:"variant_value"`
 	ExperimentID       *string `json:"experiment_id,omitempty"`
 	IsExperimentActive *bool   `json:"is_experiment_active,omitempty"`
 	IsQATester         *bool   `json:"is_qa_tester,omitempty"`
+	VariantSource      string  `json:"variant_source,omitempty"`
+	// FallbackReason is empty on success; one of the FallbackReason* constants
+	// when VariantSource is VariantSourceFallback.
+	FallbackReason string `json:"fallback_reason,omitempty"`
+}
+
+// WithSource returns a copy of v tagged with the given source. Clears
+// FallbackReason — use AsFallback when returning a fallback.
+func (v SelectedVariant) WithSource(source string) SelectedVariant {
+	v.VariantSource = source
+	v.FallbackReason = ""
+	return v
+}
+
+// AsFallback returns a copy of v tagged as a fallback with the given reason.
+func (v SelectedVariant) AsFallback(reason string) SelectedVariant {
+	v.VariantSource = VariantSourceFallback
+	v.FallbackReason = reason
+	return v
 }
 
 type Variant struct {


### PR DESCRIPTION
## Summary

- `SelectedVariant.VariantSource` (always set): `local` | `remote` | `fallback`. Constants: `VariantSourceLocal` / `VariantSourceRemote` / `VariantSourceFallback`.
- `SelectedVariant.FallbackReason` (set only when source is fallback): `FLAG_NOT_FOUND` | `MISSING_CONTEXT_KEY` | `NO_ROLLOUT_MATCH` | `BACKEND_ERROR` | `NOT_READY`. Constants: `FallbackReasonFlagNotFound` etc.
- `WithSource(source)` / `AsFallback(reason)` helpers on `SelectedVariant`.
- `LocalFeatureFlagsProvider` and `RemoteFeatureFlagsProvider` tag every returned variant: matches with `WithSource(...)`, fallbacks with `AsFallback(reason)` carrying the specific reason.

## Why

Three behaviorally distinct outcomes — flag-not-found, no-rollout-match, and missing-context-key — previously all returned the bare fallback. A future OpenFeature wrapper (in `openfeature/`) can now dispatch on the reason and map each to the spec-correct error code instead of collapsing them all to `FLAG_NOT_FOUND`.

Two flat fields rather than a discriminated union because Go's interface system makes sealed sums awkward; the two-field shape matches Python / Ruby / Node / PHP. Constant set matches `mixpanel-php`.

Cross-SDK fix tracked at Linear SDK-79.

## Follow-up PR

The `openfeature/` module needs a matching update to dispatch on `FallbackReason` — that PR depends on this one being tagged in a new `mixpanel-go/v2` release first (the openfeature module is its own Go module and consumes the tagged version). It'll come right after release.

## Test plan

- [x] All flags tests pass (`go test ./flags/...`)
- [x] 4 new SDK-level assertions (one per tagged path: LOCAL / FLAG_NOT_FOUND / MISSING_CONTEXT_KEY / NO_ROLLOUT_MATCH) added to `flags/localFlags_test.go`
- [ ] Wrapper PR pending base SDK release (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
