### PR TITLE
fix(analytics): allow capability to offload reportExposure to async thread (SDK-80)

### DIFF
--- a/flags/flagsProvider.go
+++ b/flags/flagsProvider.go
@@ -14,12 +14,13 @@ import (
 // The featureFlagsProvider contains common fields and methods shared by providers.
 // i.e LocalFeatureFlagsProvider and RemoteFeatureFlagsProvider
 type featureFlagsProvider struct {
-	token          string
-	apiHost        string
-	version        string
-	evaluationMode string
-	tracker        Tracker
-	client         *http.Client
+	token            string
+	apiHost          string
+	version          string
+	evaluationMode   string
+	tracker          Tracker
+	client           *http.Client
+	exposureExecutor func(send func())
 }
 
 // Manually tracks a feature flag exposure event to Mixpanel.
@@ -54,7 +55,12 @@ func (p *featureFlagsProvider) trackExposure(flagKey string, variant SelectedVar
 		properties["Variant fetch latency (ms)"] = float64(latency.Milliseconds())
 	}
 
-	p.tracker(distinctID, exposureEventName, properties)
+	send := func() { p.tracker(distinctID, exposureEventName, properties) }
+	if p.exposureExecutor != nil {
+		p.exposureExecutor(send)
+		return
+	}
+	send()
 }
 
 // callFlagsEndpoint makes an HTTP GET request to a flags API endpoint.

--- a/flags/localFlags.go
+++ b/flags/localFlags.go
@@ -48,12 +48,13 @@ func NewLocalFeatureFlagsProvider(token string, version string, config LocalFlag
 	}
 	provider := &LocalFeatureFlagsProvider{
 		featureFlagsProvider: featureFlagsProvider{
-			token:          token,
-			apiHost:        config.APIHost,
-			version:        version,
-			evaluationMode: "local",
-			tracker:        tracker,
-			client:         client,
+			token:            token,
+			apiHost:          config.APIHost,
+			version:          version,
+			evaluationMode:   "local",
+			tracker:          tracker,
+			client:           client,
+			exposureExecutor: config.ExposureExecutor,
 		},
 		config:         config,
 		stopPolling:    make(chan struct{}),

--- a/flags/localFlags_test.go
+++ b/flags/localFlags_test.go
@@ -537,3 +537,49 @@ func TestLowercaseKeysAndValues(t *testing.T) {
 		require.Equal(t, "john", user["name"])
 	})
 }
+
+func TestLocalFeatureFlagsProvider_ExposureExecutor(t *testing.T) {
+	t.Run("invokes ExposureExecutor instead of calling tracker inline", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var executorCalls int
+		var capturedSend func()
+		config := DefaultLocalFlagsConfig()
+		config.EnablePolling = false
+		config.ExposureExecutor = func(send func()) {
+			executorCalls++
+			capturedSend = send
+		}
+
+		var trackerCalls int
+		tracker := func(_ string, _ string, _ map[string]any) { trackerCalls++ }
+
+		provider := NewLocalFeatureFlagsProvider("test-token", "test", config, tracker)
+
+		flags := experimentationFlagsResponse{
+			Flags: []ExperimentationFlag{{
+				ID: "flag-1", Key: "test-flag", Context: "distinct_id",
+				Ruleset: RuleSet{
+					Variants: []Variant{{Key: "variant", Value: "test", Split: 1.0}},
+					Rollout:  []Rollout{{RolloutPercentage: 1.0}},
+				},
+			}},
+		}
+		httpmock.RegisterResponder(http.MethodGet, "https://api.mixpanel.com/flags/definitions",
+			httpmock.NewJsonResponderOrPanic(200, flags))
+
+		ctx := context.Background()
+		require.NoError(t, provider.StartPollingForDefinitions(ctx))
+
+		_, err := provider.GetVariant(ctx, "test-flag", SelectedVariant{}, FlagContext{"distinct_id": "user123"}, true)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, executorCalls, "executor should be invoked once")
+		require.Equal(t, 0, trackerCalls, "tracker should not be called inline when executor is set")
+		require.NotNil(t, capturedSend)
+
+		capturedSend()
+		require.Equal(t, 1, trackerCalls, "running the captured send closure invokes the tracker")
+	})
+}

--- a/flags/localFlags_test.go
+++ b/flags/localFlags_test.go
@@ -582,4 +582,61 @@ func TestLocalFeatureFlagsProvider_ExposureExecutor(t *testing.T) {
 		capturedSend()
 		require.Equal(t, 1, trackerCalls, "running the captured send closure invokes the tracker")
 	})
+
+	t.Run("nil ExposureExecutor runs tracker inline (default)", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var trackerCalls int
+		config := DefaultLocalFlagsConfig()
+		config.EnablePolling = false
+		require.Nil(t, config.ExposureExecutor)
+
+		tracker := func(_ string, _ string, _ map[string]any) { trackerCalls++ }
+		provider := NewLocalFeatureFlagsProvider("test-token", "test", config, tracker)
+
+		flags := experimentationFlagsResponse{
+			Flags: []ExperimentationFlag{{
+				ID: "flag-1", Key: "test-flag", Context: "distinct_id",
+				Ruleset: RuleSet{
+					Variants: []Variant{{Key: "variant", Value: "test", Split: 1.0}},
+					Rollout:  []Rollout{{RolloutPercentage: 1.0}},
+				},
+			}},
+		}
+		httpmock.RegisterResponder(http.MethodGet, "https://api.mixpanel.com/flags/definitions",
+			httpmock.NewJsonResponderOrPanic(200, flags))
+
+		ctx := context.Background()
+		require.NoError(t, provider.StartPollingForDefinitions(ctx))
+
+		_, err := provider.GetVariant(ctx, "test-flag", SelectedVariant{}, FlagContext{"distinct_id": "user123"}, true)
+		require.NoError(t, err)
+		require.Equal(t, 1, trackerCalls)
+	})
+
+	t.Run("TrackExposureEvent (manual API) also honors ExposureExecutor", func(t *testing.T) {
+		var capturedSend func()
+		var executorCalls int
+		config := DefaultLocalFlagsConfig()
+		config.EnablePolling = false
+		config.ExposureExecutor = func(send func()) {
+			executorCalls++
+			capturedSend = send
+		}
+
+		var trackerCalls int
+		tracker := func(_ string, _ string, _ map[string]any) { trackerCalls++ }
+		provider := NewLocalFeatureFlagsProvider("test-token", "test", config, tracker)
+
+		variantKey := "treatment"
+		provider.TrackExposureEvent(context.Background(), "manual-flag",
+			SelectedVariant{VariantKey: &variantKey, VariantValue: "x"},
+			FlagContext{"distinct_id": "user123"})
+
+		require.Equal(t, 1, executorCalls)
+		require.Equal(t, 0, trackerCalls)
+		capturedSend()
+		require.Equal(t, 1, trackerCalls)
+	})
 }

--- a/flags/remoteFlags.go
+++ b/flags/remoteFlags.go
@@ -33,12 +33,13 @@ func NewRemoteFeatureFlagsProvider(token string, version string, config RemoteFl
 	}
 	return &RemoteFeatureFlagsProvider{
 		featureFlagsProvider: featureFlagsProvider{
-			token:          token,
-			apiHost:        config.APIHost,
-			version:        version,
-			evaluationMode: "remote",
-			tracker:        tracker,
-			client:         client,
+			token:            token,
+			apiHost:          config.APIHost,
+			version:          version,
+			evaluationMode:   "remote",
+			tracker:          tracker,
+			client:           client,
+			exposureExecutor: config.ExposureExecutor,
 		},
 		config: config,
 	}

--- a/flags/remoteFlags_test.go
+++ b/flags/remoteFlags_test.go
@@ -263,6 +263,96 @@ func TestRemoteFeatureFlagsProvider_ExposureTracking(t *testing.T) {
 	})
 }
 
+func TestRemoteFeatureFlagsProvider_ExposureExecutor(t *testing.T) {
+	t.Run("invokes ExposureExecutor instead of calling tracker inline", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var executorCalls int
+		var capturedSend func()
+		config := DefaultRemoteFlagsConfig()
+		config.ExposureExecutor = func(send func()) {
+			executorCalls++
+			capturedSend = send
+		}
+
+		var trackerCalls int
+		tracker := func(_ string, _ string, _ map[string]any) { trackerCalls++ }
+
+		provider := NewRemoteFeatureFlagsProvider("test-token", "test", config, tracker)
+
+		variantKey := "enabled"
+		response := remoteFlagsResponse{
+			Code: 200,
+			Flags: map[string]*SelectedVariant{
+				"test-flag": {VariantKey: &variantKey, VariantValue: true},
+			},
+		}
+		httpmock.RegisterResponder(http.MethodGet, "https://api.mixpanel.com/flags",
+			httpmock.NewJsonResponderOrPanic(200, response))
+
+		ctx := context.Background()
+		_, err := provider.GetVariant(ctx, "test-flag", SelectedVariant{}, FlagContext{"distinct_id": "user123"}, true)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, executorCalls)
+		require.Equal(t, 0, trackerCalls, "tracker must not run inline when executor is set")
+		capturedSend()
+		require.Equal(t, 1, trackerCalls)
+	})
+
+	t.Run("nil ExposureExecutor runs tracker inline (default)", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		var trackerCalls int
+		config := DefaultRemoteFlagsConfig()
+		require.Nil(t, config.ExposureExecutor)
+
+		tracker := func(_ string, _ string, _ map[string]any) { trackerCalls++ }
+		provider := NewRemoteFeatureFlagsProvider("test-token", "test", config, tracker)
+
+		variantKey := "enabled"
+		response := remoteFlagsResponse{
+			Code: 200,
+			Flags: map[string]*SelectedVariant{
+				"test-flag": {VariantKey: &variantKey, VariantValue: true},
+			},
+		}
+		httpmock.RegisterResponder(http.MethodGet, "https://api.mixpanel.com/flags",
+			httpmock.NewJsonResponderOrPanic(200, response))
+
+		ctx := context.Background()
+		_, err := provider.GetVariant(ctx, "test-flag", SelectedVariant{}, FlagContext{"distinct_id": "user123"}, true)
+		require.NoError(t, err)
+		require.Equal(t, 1, trackerCalls)
+	})
+
+	t.Run("TrackExposureEvent (manual API) also honors ExposureExecutor", func(t *testing.T) {
+		var capturedSend func()
+		var executorCalls int
+		config := DefaultRemoteFlagsConfig()
+		config.ExposureExecutor = func(send func()) {
+			executorCalls++
+			capturedSend = send
+		}
+
+		var trackerCalls int
+		tracker := func(_ string, _ string, _ map[string]any) { trackerCalls++ }
+		provider := NewRemoteFeatureFlagsProvider("test-token", "test", config, tracker)
+
+		variantKey := "treatment"
+		provider.TrackExposureEvent(context.Background(), "manual-flag",
+			SelectedVariant{VariantKey: &variantKey, VariantValue: "x"},
+			FlagContext{"distinct_id": "user123"})
+
+		require.Equal(t, 1, executorCalls)
+		require.Equal(t, 0, trackerCalls)
+		capturedSend()
+		require.Equal(t, 1, trackerCalls)
+	})
+}
+
 func TestRemoteFeatureFlagsProvider_RequestFormat(t *testing.T) {
 	t.Run("sends correct query parameters", func(t *testing.T) {
 		httpmock.Activate()

--- a/flags/types.go
+++ b/flags/types.go
@@ -24,6 +24,10 @@ type FlagsConfig struct {
 	APIHost        string
 	RequestTimeout time.Duration
 	HTTPClient     *http.Client
+	// ExposureExecutor, if set, runs the exposure tracker call so flag
+	// evaluation does not block on the /track round trip. nil keeps the
+	// existing inline behavior. Typical implementation: `func(send func()) { go send() }`.
+	ExposureExecutor func(send func())
 }
 
 type LocalFlagsConfig struct {

--- a/openfeature/README.md
+++ b/openfeature/README.md
@@ -187,6 +187,29 @@ When your application is shutting down, call `Shutdown()` to stop background pol
 provider.Shutdown()
 ```
 
+### Async Exposure Tracking
+
+By default, every flag evaluation tracks an exposure event inline — the `/track` HTTP round trip happens on the calling goroutine before the evaluation method returns. For latency-sensitive code paths, set `ExposureExecutor` on the config so exposure tracking runs off-goroutine:
+
+```go
+config := flags.DefaultLocalFlagsConfig()
+config.ExposureExecutor = func(send func()) { go send() }
+
+provider, _ := mixpanelopenfeature.NewProviderWithLocalConfig("YOUR_TOKEN", config)
+```
+
+For a bounded worker pool:
+
+```go
+sem := make(chan struct{}, 4)
+config.ExposureExecutor = func(send func()) {
+    sem <- struct{}{}
+    go func() { defer func() { <-sem }(); send() }()
+}
+```
+
+Available on both `LocalFlagsConfig` and `RemoteFlagsConfig`. Defaults to `nil` (inline behavior); existing setups are unaffected.
+
 ## Context Mapping
 
 All properties in the OpenFeature `EvaluationContext` are passed directly to Mixpanel's flag evaluation. There is no transformation or filtering of properties.

--- a/openfeature/README.md
+++ b/openfeature/README.md
@@ -198,15 +198,28 @@ config.ExposureExecutor = func(send func()) { go send() }
 provider, _ := mixpanelopenfeature.NewProviderWithLocalConfig("YOUR_TOKEN", config)
 ```
 
-For a bounded worker pool:
+For bounded concurrency that never blocks the caller, use a non-blocking
+`select` — exposures are dropped once the in-flight cap is reached:
 
 ```go
 sem := make(chan struct{}, 4)
 config.ExposureExecutor = func(send func()) {
-    sem <- struct{}{}
-    go func() { defer func() { <-sem }(); send() }()
+    select {
+    case sem <- struct{}{}:
+        go func() {
+            defer func() { <-sem }()
+            send()
+        }()
+    default:
+        // At capacity — drop the exposure rather than stall the caller.
+    }
 }
 ```
+
+If you'd rather queue than drop, back the executor with a pre-spawned
+worker pool that reads from a buffered channel — that keeps the caller
+non-blocking as long as the queue has room, and lets you decide the
+buffer size and worker count explicitly.
 
 Available on both `LocalFlagsConfig` and `RemoteFlagsConfig`. Defaults to `nil` (inline behavior); existing setups are unaffected.
 


### PR DESCRIPTION
## Summary

Exposure tracking on every `GetVariant` / `GetVariantValue` / `IsEnabled` call invoked the tracker — and therefore an HTTP POST — inline, blocking flag evaluation by the full `/track` round trip.

Add an optional `ExposureExecutor func(send func())` field on `FlagsConfig` (inherited by both `LocalFlagsConfig` and `RemoteFlagsConfig`). When set, the provider hands the tracker closure to the executor instead of calling it inline. `nil` (the default) preserves the existing inline behavior — no breaking change for current users.

## Usage

```go
config := flags.DefaultLocalFlagsConfig()
config.ExposureExecutor = func(send func()) { go send() }

// Or with a bounded worker pool:
sem := make(chan struct{}, 4)
config.ExposureExecutor = func(send func()) {
    sem <- struct{}{}
    go func() { defer func() { <-sem }(); send() }()
}
```

## Context

Linear: [SDK-80](https://linear.app/mixpanel/issue/SDK-80/synchronous-reportexposure-blocks-eval-on-http). Mirrors [mixpanel-java#85](https://github.com/mixpanel/mixpanel-java/pull/85). Audit-driven; same fix being applied to mixpanel-python and mixpanel-ruby in parallel PRs.

## Test plan

- [x] Full `go test ./flags/...` passes (the existing inline-exposure tests still pass — `nil` keeps the old behavior unchanged)
- [x] New `TestLocalFeatureFlagsProvider_ExposureExecutor` asserts: the executor is invoked exactly once per exposure, the tracker is NOT called inline when an executor is configured, and the closure handed to the executor invokes the tracker when run

