### PR TITLE
chore(ci): add allow_existing_tag input to prepare-release for backfill

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -11,6 +11,11 @@ on:
         description: 'Release version (e.g., 2.1.0 or 2.1.0-beta.1)'
         required: true
         type: string
+      allow_existing_tag:
+        description: 'Skip the tag-already-exists guard (use to backfill CHANGELOG/README for a tag that was pushed without going through this workflow).'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -64,6 +69,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Validate version not already released
+        if: ${{ !inputs.allow_existing_tag }}
         env:
           TAG: ${{ steps.config.outputs.tag }}
         run: |


### PR DESCRIPTION
## Summary

The `Validate version not already released` step is a hard exit when the tag already exists on origin. That's the right default (prevents silently re-preparing a released version) but blocks backfilling CHANGELOG/README for a tag that was pushed without going through this workflow — which just happened with `openfeature/v0.2.0`: tag published, publish workflow succeeded, but `openfeature/CHANGELOG.md` and the README version header on main still reflect `v0.1.0`.

Add an `allow_existing_tag` input (default `false`). When set to `true`, the validate step is skipped so prepare-release will generate a normal "release: prepare X" PR against main containing the CHANGELOG entry and README update. Merging that PR gets docs into a consistent state without disturbing the existing tag or published release.

## Test plan

- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] After merge: dispatch prepare-release with `module: openfeature`, `version: 0.2.0`, `allow_existing_tag: true` → verify PR is created against main with CHANGELOG + README updates
- [ ] Same change should be ported to mixpanel-ruby / -python / -node prep-release workflows once the pattern is validated here

🤖 Generated with [Claude Code](https://claude.com/claude-code)