### PR TITLE
release: prepare openfeature 0.2.0 (backfill)

### DIFF
--- a/openfeature/CHANGELOG.md
+++ b/openfeature/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [openfeature/v0.2.0](https://github.com/mixpanel/mixpanel-go/tree/openfeature/v0.2.0) (2026-07-28)
+
+### Features
+- dispatch on FallbackReason instead of nil-VariantKey (SDK-130) ([#101](https://github.com/mixpanel/mixpanel-go/pull/101))
+
+[Full Changelog](https://github.com/mixpanel/mixpanel-go/compare/openfeature/v0.1.0...openfeature/v0.2.0)
+
 ## [openfeature/v0.1.0](https://github.com/mixpanel/mixpanel-go/tree/openfeature/v0.1.0) (2026-05-13)
 
 Initial entry. Future releases will be appended here automatically by the

--- a/openfeature/README.md
+++ b/openfeature/README.md
@@ -1,6 +1,6 @@
 # Mixpanel OpenFeature Provider for Go
 
-##### _May 13, 2026_ - [openfeature/v0.1.0](https://github.com/mixpanel/mixpanel-go/releases/tag/openfeature/v0.1.0)
+##### _July 28, 2026_ - [openfeature/v0.2.0](https://github.com/mixpanel/mixpanel-go/releases/tag/openfeature/v0.2.0)
 
 An [OpenFeature](https://openfeature.dev/) provider that wraps Mixpanel's feature flags for use with the OpenFeature Go SDK. This allows you to use Mixpanel's feature flagging capabilities through OpenFeature's standardized, vendor-agnostic API.
 


### PR DESCRIPTION
## Summary

Backfill of the CHANGELOG and README updates that the `prepare-release` workflow would have generated for `openfeature/v0.2.0`.

`openfeature/v0.2.0` was tagged directly on the merge commit of #101 without running prepare-release first, so the tag published cleanly (Go's publish workflow only needs the tag, not a version file) but `openfeature/CHANGELOG.md` and `openfeature/README.md`'s version header stayed at `v0.1.0` on main. Without this, the next release's auto-generated changelog would silently omit v0.2.0's changes (the generator diffs from the previous tag → HEAD).

## Changes

- `openfeature/CHANGELOG.md`: prepends the `openfeature/v0.2.0` section (generated by running `.github/scripts/generate-changelog.sh openfeature openfeature/v0.2.0 ... 503eedd` locally with the local v0.2.0 tag temporarily removed so PREVIOUS_TAG resolves to v0.1.0).
- `openfeature/README.md`: version header line updated to point at `openfeature/v0.2.0` with today's date, matching the workflow's sed.

No code changes. Doesn't disturb the existing tag or published release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)